### PR TITLE
fix: use local state updates for watchlist member mutations

### DIFF
--- a/src/app/watchlist/[id]/page.tsx
+++ b/src/app/watchlist/[id]/page.tsx
@@ -311,14 +311,22 @@ export default function WatchlistDetailPage() {
             signal: abortRef.current.signal,
           });
         }
-        await loadData();
+        // Reload only this member instead of the entire list
+        const memberRes = await fetch(`${api}/members`, { signal: abortRef.current.signal });
+        const memberJson = await memberRes.json().catch(() => null);
+        if (memberRes.ok && memberJson?.success) {
+          const updated = (memberJson.data as WatchlistMember[])?.find((m) => m.id === member.id);
+          if (updated) {
+            setMembers((prev) => prev.map((m) => (m.id === updated.id ? updated : m)));
+          }
+        }
       }
     } catch {
       // ignore abort / network errors
     } finally {
       setRefreshingMemberId(null);
     }
-  }, [api, loadData]);
+  }, [api]);
 
   // ── Auto-translate via SSE stream ──
 
@@ -1037,7 +1045,7 @@ export default function WatchlistDetailPage() {
         open={addOpen}
         onOpenChange={setAddOpen}
         allTags={allTags}
-        onSuccess={loadData}
+        onSuccess={(newMember) => setMembers((prev) => [...prev, newMember])}
         onTagCreated={(tag) => setAllTags((prev) => [...prev, tag])}
         watchlistId={watchlistId}
       />
@@ -1049,7 +1057,10 @@ export default function WatchlistDetailPage() {
           onOpenChange={(open) => !open && setEditMember(null)}
           member={editMember}
           allTags={allTags}
-          onSuccess={loadData}
+          onSuccess={(updated) => {
+            setMembers((prev) => prev.map((m) => (m.id === updated.id ? updated : m)));
+            setEditMember(null);
+          }}
           onTagCreated={(tag) => setAllTags((prev) => [...prev, tag])}
           watchlistId={watchlistId}
         />
@@ -1061,7 +1072,10 @@ export default function WatchlistDetailPage() {
           open={!!deleteMember}
           onOpenChange={(open) => !open && setDeleteMember(null)}
           member={deleteMember}
-          onSuccess={loadData}
+          onSuccess={(memberId) => {
+            setMembers((prev) => prev.filter((m) => m.id !== memberId));
+            setDeleteMember(null);
+          }}
           watchlistId={watchlistId}
         />
       )}

--- a/src/app/watchlist/_components/add-member-dialog.tsx
+++ b/src/app/watchlist/_components/add-member-dialog.tsx
@@ -25,7 +25,7 @@ export function AddMemberDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   allTags: TagData[];
-  onSuccess: () => void;
+  onSuccess: (member: import("../_lib/types").WatchlistMember) => void;
   onTagCreated: (tag: TagData) => void;
   watchlistId: number;
 }) {
@@ -68,7 +68,7 @@ export function AddMemberDialog({
 
       reset();
       onOpenChange(false);
-      onSuccess();
+      onSuccess(json.data);
     } catch {
       setError("Network error");
     } finally {

--- a/src/app/watchlist/_components/delete-member-dialog.tsx
+++ b/src/app/watchlist/_components/delete-member-dialog.tsx
@@ -22,7 +22,7 @@ export function DeleteMemberDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   member: WatchlistMember;
-  onSuccess: () => void;
+  onSuccess: (memberId: number) => void;
   watchlistId: number;
 }) {
   const [deleting, setDeleting] = useState(false);
@@ -35,7 +35,7 @@ export function DeleteMemberDialog({
       });
       if (res.ok) {
         onOpenChange(false);
-        onSuccess();
+        onSuccess(member.id);
       }
     } catch {
       // silent

--- a/src/app/watchlist/_components/edit-member-dialog.tsx
+++ b/src/app/watchlist/_components/edit-member-dialog.tsx
@@ -27,7 +27,7 @@ export function EditMemberDialog({
   onOpenChange: (open: boolean) => void;
   member: WatchlistMember;
   allTags: TagData[];
-  onSuccess: () => void;
+  onSuccess: (member: import("../_lib/types").WatchlistMember) => void;
   onTagCreated: (tag: TagData) => void;
   watchlistId: number;
 }) {
@@ -61,7 +61,7 @@ export function EditMemberDialog({
       }
 
       onOpenChange(false);
-      onSuccess();
+      onSuccess(json.data);
     } catch {
       setError("Network error");
     } finally {


### PR DESCRIPTION
## Summary
- Replace full `loadData()` (4 API calls) with local `setMembers` updates for add/edit/delete member operations
- Optimize single profile refresh to only fetch members endpoint instead of full reload
- Eliminates member list flicker when adding/editing/deleting a single user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized member management: adding, editing, and deleting watchlist members now updates the UI instantly without reloading all data, reducing network traffic and improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->