### PR TITLE
fix: initialize database before auth adapter access

### DIFF
--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Adapter } from "@auth/core/adapters";
-import { getRawSqlite } from "@/db";
+import { getRawSqlite, getDb } from "@/db";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
@@ -36,7 +36,7 @@ function rowToUser(row: Row) {
 export function SqliteAdapter(): Adapter {
   // Lazy ref — getRawSqlite() may not be ready at import time.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sql = () => getRawSqlite() as any;
+  const sql = () => { getDb(); return getRawSqlite() as any; };
 
   return {
     async createUser(user) {


### PR DESCRIPTION
## Summary

- **Bug**: `SqliteAdapter` crashes with `AdapterError: No database connection` on fresh deploys (first-ever login) because `getRawSqlite()` returns `null` when `getDb()` has never been called to initialize the database connection.
- **Fix**: Call `getDb()` (which is idempotent — returns the existing instance if already initialized) inside the `sql()` helper before accessing the raw SQLite instance. This guarantees the database is always initialized when the auth adapter needs it.

## Changes

In `src/lib/auth-adapter.ts`:

1. Added `getDb` to the import from `@/db`
2. Updated the `sql()` helper to call `getDb()` before `getRawSqlite()`:
   ```ts
   // Before
   const sql = () => getRawSqlite() as any;
   // After
   const sql = () => { getDb(); return getRawSqlite() as any; };
   ```

## Test plan

- [ ] `bun install && bun run db:push && bun dev`
- [ ] Delete existing database file to simulate fresh deploy
- [ ] Attempt Google OAuth login — should succeed without `AdapterError: No database connection`
- [ ] Verify returning user login still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)