### PR TITLE
fix: ensure database is initialized before auth adapter queries

### DIFF
--- a/src/lib/auth-adapter.ts
+++ b/src/lib/auth-adapter.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Adapter } from "@auth/core/adapters";
-import { getRawSqlite } from "@/db";
+import { getRawSqlite, getDb } from "@/db";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
@@ -36,7 +36,7 @@ function rowToUser(row: Row) {
 export function SqliteAdapter(): Adapter {
   // Lazy ref — getRawSqlite() may not be ready at import time.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sql = () => getRawSqlite() as any;
+  const sql = () => { getDb(); return getRawSqlite() as any; };
 
   return {
     async createUser(user) {


### PR DESCRIPTION
## Summary

- Fix a bug where the `SqliteAdapter` crashes when it is the first code to access the database during NextAuth sign-in flow
- The root cause is that `getRawSqlite()` was called without first ensuring the database connection and schema are initialized via `getDb()`

## Changes

- **`src/lib/auth-adapter.ts`**: Import `getDb` alongside `getRawSqlite` from `@/db`
- **`src/lib/auth-adapter.ts`**: Update the lazy `sql()` helper inside `SqliteAdapter()` to call `getDb()` before `getRawSqlite()`, guaranteeing that `createDatabase()` → `initSchema()` has run and all required tables exist

## Test Plan

- Sign in with Google OAuth on a fresh deployment (no existing database file) — the auth flow should complete without "no such table" errors
- Existing deployments with an already-initialized database are unaffected since `getDb()` is idempotent

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)