### PR TITLE
style(sidebar): brand tracking-tight → tracking-tighter

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -678,7 +678,7 @@ export function Sidebar() {
                     height={24}
                     className="shrink-0"
                   />
-                  <span className="text-lg font-bold tracking-tight font-mono">
+                  <span className="text-lg font-bold tracking-tighter font-mono">
                     X-Ray
                   </span>
                   <Badge


### PR DESCRIPTION
Closes #9

## Changes
- `sidebar.tsx`: tracking-tight → tracking-tighter (font-mono retained for X-Ray brand)

Per Basalt B02-2c.