### PR TITLE
ci: upgrade to eslint strict config for 6DQ G1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
-        "hono": "^4.12.12",
         "lucide-react": "^0.577.0",
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "^1.4.3",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 const eslintConfig = defineConfig([
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.strict,
   globalIgnores([
     ".next/**",
     ".next-e2e/**",
@@ -16,19 +16,7 @@ const eslintConfig = defineConfig([
     "tests/**",
     // Playwright E2E tests (not React code)
     "e2e/**",
-
   ]),
-  // Key rules from typescript-eslint strict preset (no type-checking required)
-  {
-    rules: {
-      "@typescript-eslint/no-explicit-any": "error",
-      "@typescript-eslint/no-non-null-assertion": "error",
-      "@typescript-eslint/no-dynamic-delete": "error",
-      "@typescript-eslint/no-extraneous-class": "error",
-      "@typescript-eslint/unified-signatures": "error",
-      "@typescript-eslint/no-invalid-void-type": "error",
-    },
-  },
   // Relax non-null-assertion in test files (common pattern: result!.field)
   {
     files: ["src/__tests__/**"],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vinext dev --port 7007",
     "build": "vinext build",
     "start": "vinext start --port 7007",
-    "lint": "eslint",
+    "lint": "eslint --max-warnings=0",
     "test": "find tests src/__tests__ -name '*.test.ts' ! -path '*/e2e/*' -print0 | xargs -0 bun test && bun test src/__tests__/e2e/",
     "test:coverage": "bun test --coverage",
     "test:e2e:browser": "npx playwright test",

--- a/src/__tests__/db/groups.test.ts
+++ b/src/__tests__/db/groups.test.ts
@@ -95,7 +95,7 @@ describe("repositories/groups", () => {
 
       const mine = groups.findAll();
       expect(mine).toHaveLength(1);
-      expect(mine[0].name).toBe("My Group");
+      expect(mine[0]!.name).toBe("My Group");
     });
 
     test("returns all groups for this user", () => {
@@ -315,16 +315,16 @@ describe("repositories/groupMembers", () => {
 
       const result = members.findByGroupId(groupId);
       expect(result).toHaveLength(1);
-      expect(result[0].profile).not.toBeNull();
-      expect(result[0].profile!.twitterId).toBe("555");
-      expect(result[0].profile!.followersCount).toBe(1000);
+      expect(result[0]!.profile).not.toBeNull();
+      expect(result[0]!.profile!.twitterId).toBe("555");
+      expect(result[0]!.profile!.followersCount).toBe(1000);
     });
 
     test("returns null profile for unresolved members", () => {
       members.create({ groupId, twitterUsername: "noProfile" });
       const result = members.findByGroupId(groupId);
       expect(result).toHaveLength(1);
-      expect(result[0].profile).toBeNull();
+      expect(result[0]!.profile).toBeNull();
     });
   });
 
@@ -417,8 +417,8 @@ describe("repositories/groupMembers", () => {
       expect(linked).toBe(1);
 
       const result = members.findByGroupId(groupId);
-      expect(result[0].twitterId).toBe("888");
-      expect(result[0].profile).not.toBeNull();
+      expect(result[0]!.twitterId).toBe("888");
+      expect(result[0]!.profile).not.toBeNull();
     });
 
     test("returns 0 when all members already linked", () => {


### PR DESCRIPTION
Upgrades eslint from recommended to strict config, adds `--max-warnings=0`.

6DQ compliance: G1 (lint strict) → enables Tier B.