### PR TITLE
ci: enable L2 API E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,6 @@ jobs:
     with:
       test-command: "find tests src/__tests__ -name '*.test.ts' ! -path '*/e2e/*' -print0 | xargs -0 bun test"
       typecheck-command: "echo 'no typecheck configured'"
-      enable-l2: "false"
+      enable-l2: "true"
+      l2-command: "bun run test:e2e:api"
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint --max-warnings=0",
     "test": "find tests src/__tests__ -name '*.test.ts' ! -path '*/e2e/*' -print0 | xargs -0 bun test && bun test src/__tests__/e2e/",
     "test:coverage": "bun test --coverage",
+    "test:e2e:api": "bun test src/__tests__/e2e/ --timeout 90000",
     "test:e2e:browser": "npx playwright test",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/src/__tests__/e2e/auth-settings.e2e.test.ts
+++ b/src/__tests__/e2e/auth-settings.e2e.test.ts
@@ -295,10 +295,12 @@ describe("e2e: auth and settings", () => {
 
       const data = await res.json();
       expect(data.status).toBe("ok");
-      expect(typeof data.timestamp).toBe("number");
+      expect(typeof data.timestamp).toBe("string");
       expect(typeof data.uptime).toBe("number");
-      expect(data.checks).toBeDefined();
-      expect(data.checks.database).toBe("ok");
+      expect(data.component).toBe("xray");
+      expect(typeof data.version).toBe("string");
+      expect(data.database).toBeDefined();
+      expect(data.database.connected).toBe(true);
     });
   });
 


### PR DESCRIPTION
Enable L2 integration/API E2E tests in CI pipeline.\n\n- Enable L2 in CI workflow\n- Fix test compatibility for CI environment