### PR TITLE
test(e2e): build + start prod server in CI to fix L3 hydration flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ playwright-report/
 npm-debug.log*
 
 # Next.js / vinext
+.vinext/
 next-env.d.ts
 tsconfig.tsbuildinfo
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,17 @@ import { defineConfig, devices } from "@playwright/test";
 
 const E2E_PORT = 27028;
 
+// Use a production build under CI (or when E2E_PROD=1) to avoid vinext dev's
+// on-demand compilation + hydration race that flakes locator interactions on
+// slow runners — symptoms were "button disabled / locator timeout" because
+// Playwright's fill()/click() reached the DOM before React hydrated. Local
+// dev keeps the fast `vinext dev` loop for iteration speed.
+const useProdServer = !!process.env.CI || process.env.E2E_PROD === "1";
+const webServerCommand = useProdServer
+  ? `bunx vinext build && bunx vinext start --port ${E2E_PORT}`
+  : `bunx vinext dev --port ${E2E_PORT}`;
+const webServerTimeout = useProdServer ? 180_000 : 60_000;
+
 export default defineConfig({
   testDir: "./e2e",
   testMatch: "*.pw.ts",
@@ -25,12 +36,12 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: `bunx vinext dev --port ${E2E_PORT}`,
+    command: webServerCommand,
     port: E2E_PORT,
     reuseExistingServer: !process.env.CI,
-    timeout: 60_000,
+    timeout: webServerTimeout,
     env: {
-      NODE_ENV: "development",
+      NODE_ENV: useProdServer ? "production" : "development",
       XRAY_DB: "database/xray.playwright.db",
       E2E_SKIP_AUTH: "true",
       MOCK_PROVIDER: "true",


### PR DESCRIPTION
## Summary

- L3 Playwright E2E has been failing on every CI run since it was first enabled in 3278bcc. The pattern in CI logs is identical across all 9 failing tests: locators resolve to `<button disabled>` (e.g. `Search`, `Look up`, `Create`) and stay disabled until the 30s timeout. Locally the suite is green — this is a CI-only flake.
- Root cause: vinext dev's on-demand compile + React 19 streaming hydration leaves the DOM interactive before React attaches `onChange` handlers. Playwright's `fill()` sets the input value via the DOM but React state never updates, so submit buttons gated on `disabled={!query.trim()}` never enable. Slow ubuntu runners lose the race; my M-series Mac wins it.
- Fix: switch the L3 webServer to a production build (`vinext build && vinext start`) in CI. Local `bun run test:e2e:browser` still uses `vinext dev` for fast iteration. `E2E_PROD=1` opt-in to reproduce CI exactly.

## Test plan

- [x] `CI=true bun run test:e2e:browser` → 45/45 pass (43.9s) — reproduces the CI server topology and confirms the fix
- [x] `bun run lint` → clean
- [x] `bun run test` → 1072/1072 pass
- [ ] GitHub Actions L3 Playwright E2E job goes green on this PR