### PR TITLE
test(e2e): tie reuseExistingServer to useProdServer

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   webServer: {
     command: webServerCommand,
     port: E2E_PORT,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: !useProdServer,
     timeout: webServerTimeout,
     env: {
       NODE_ENV: useProdServer ? "production" : "development",


### PR DESCRIPTION
## Summary
- Follow-up to #90 (already merged) addressing the non-blocking review suggestion.
- Change `reuseExistingServer: !process.env.CI` → `reuseExistingServer: !useProdServer` so that local `E2E_PROD=1` runs do not silently reuse a `vinext dev` server (which would defeat the purpose of opting into the prod-server topology to mirror CI).

## Test plan
- [x] L1 unit (1072 tests pass)
- [x] G1 lint, G2 OSV
- [x] L2 API E2E (209 tests pass, pre-push)
- [ ] L3 Playwright E2E (CI)