### PR TITLE
chore(deps): bump better-sqlite3 from 12.10.0 to 12.10.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@ai-sdk/openai": "^3.0.71",
         "@radix-ui/react-collapsible": "^1.1.13",
         "ai": "^6.0.204",
-        "better-sqlite3": "^12.8.0",
+        "better-sqlite3": "^12.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
@@ -24,7 +24,7 @@
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
-        "vinext": "0.1.2",
+        "vinext": "^0.1.2",
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -716,7 +716,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.35", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg=="],
 
-    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
+    "better-sqlite3": ["better-sqlite3@12.10.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ai-sdk/openai": "^3.0.71",
     "@radix-ui/react-collapsible": "^1.1.13",
     "ai": "^6.0.204",
-    "better-sqlite3": "^12.8.0",
+    "better-sqlite3": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",


### PR DESCRIPTION
## Summary

- Patch upgrade `better-sqlite3` from `12.10.0` → `12.10.1`.
- Used by the dev/Node runtime fallback (see CLAUDE.md retrospective #6) and the NextAuth SQLite adapter.

## Verification

- `bun run typecheck` ✅
- `bun run test` ✅ — 71 files / 1072 tests pass.

Closes nocoo/xray#92