### PR TITLE
security: validate forwarded host before auth redirects (STU-644)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,10 @@ GOOGLE_CLIENT_SECRET=GOCSPX-your-client-secret
 # Generate a secret with: openssl rand -base64 32
 NEXTAUTH_SECRET=your-generated-secret-here
 
-# Base URL for your application (used for callbacks)
-# Leave empty to auto-detect from request headers
+# Base URL for your application (used for callbacks and auth redirects)
+# Strongly recommended in production: when set, auth-flow redirects use this
+# canonical origin and ignore X-Forwarded-Host entirely.
+# Leave empty to auto-detect from request headers (dev only).
 NEXTAUTH_URL=
 
 # -------------------------------------------
@@ -55,3 +57,9 @@ XRAY_DATA_DIR=
 # -------------------------------------------
 # Set to "true" if using HTTPS reverse proxy in development
 USE_SECURE_COOKIES=false
+
+# Comma-separated allowlist of hostnames the app will trust from the
+# X-Forwarded-Host header when building auth-flow redirects (open-redirect
+# protection, CWE-601). Only consulted when NEXTAUTH_URL is unset.
+# Example: TRUSTED_FORWARDED_HOSTS=xray.example.com,staging.xray.example.com
+TRUSTED_FORWARDED_HOSTS=

--- a/docs/05-config-and-data.md
+++ b/docs/05-config-and-data.md
@@ -18,7 +18,8 @@ The web application is configured via `.env` file. See `.env.example` for the fu
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `NEXTAUTH_URL` | (auto-detect) | Base URL for auth callbacks |
+| `NEXTAUTH_URL` | (auto-detect) | Canonical base URL for auth callbacks. Strongly recommended in production — auth redirects ignore `X-Forwarded-Host` when this is set. |
+| `TRUSTED_FORWARDED_HOSTS` | (empty) | Comma-separated allowlist of hosts the app will trust from `X-Forwarded-Host` for auth redirects. Only consulted when `NEXTAUTH_URL` is unset. |
 | `USE_SECURE_COOKIES` | `false` | Set `true` behind HTTPS reverse proxy |
 | `XRAY_DATA_DIR` | project root | SQLite data directory (set to `/data` for Docker/Railway) |
 | `XRAY_DB` | `database/xray.db` | Custom database file path |

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -283,33 +283,9 @@ describe("auth", () => {
   // ---------------------------------------------------------------------------
 
   describe("proxy logic", () => {
-    function buildRedirectUrl(
-      forwardedHost: string | null,
-      forwardedProto: string | null,
-      origin: string,
-      pathname: string
-    ): string {
-      if (forwardedHost) {
-        const proto = forwardedProto || "https";
-        return `${proto}://${forwardedHost}${pathname}`;
-      }
-      return `${origin}${pathname}`;
-    }
-
-    test("uses origin when no forwarded headers", () => {
-      const url = buildRedirectUrl(null, null, "http://localhost:7007", "/login");
-      expect(url).toBe("http://localhost:7007/login");
-    });
-
-    test("uses forwarded host with forwarded proto", () => {
-      const url = buildRedirectUrl("xray.example.com", "https", "http://localhost:7007", "/login");
-      expect(url).toBe("https://xray.example.com/login");
-    });
-
-    test("defaults to https when forwarded host present but no proto", () => {
-      const url = buildRedirectUrl("xray.example.com", null, "http://localhost:7007", "/login");
-      expect(url).toBe("https://xray.example.com/login");
-    });
+    // Redirect-URL resolution lives in src/lib/redirect-url.ts and is covered
+    // by src/__tests__/redirect-url.test.ts — see that file for the security
+    // contract around untrusted x-forwarded-host headers (CWE-601).
 
     // Route matching logic
     function routeDecision(

--- a/src/__tests__/redirect-url.test.ts
+++ b/src/__tests__/redirect-url.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from "vitest";
+import {
+  parseTrustedHosts,
+  resolveRedirectUrl,
+} from "@/lib/redirect-url";
+
+describe("parseTrustedHosts", () => {
+  test("returns empty array when env is undefined", () => {
+    expect(parseTrustedHosts(undefined)).toEqual([]);
+  });
+
+  test("trims, lowercases, and drops blanks", () => {
+    expect(
+      parseTrustedHosts("  Xray.Example.com , , other.example.com  ")
+    ).toEqual(["xray.example.com", "other.example.com"]);
+  });
+});
+
+describe("resolveRedirectUrl", () => {
+  const requestOrigin = "https://xray.example.com";
+
+  // ---------------------------------------------------------------------------
+  // Configured canonical URL wins
+  // ---------------------------------------------------------------------------
+
+  test("NEXTAUTH_URL takes precedence over forwarded host", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "evil.attacker.com",
+      forwardedProto: "https",
+      requestOrigin,
+      pathname: "/login",
+      configuredUrl: "https://xray.example.com",
+    });
+    expect(url).toBe("https://xray.example.com/login");
+  });
+
+  test("NEXTAUTH_URL is used even when forwarded headers are absent", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: null,
+      forwardedProto: null,
+      requestOrigin: "http://internal.local:7007",
+      pathname: "/",
+      configuredUrl: "https://xray.example.com",
+    });
+    expect(url).toBe("https://xray.example.com/");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Untrusted forwarded host is REJECTED — this is the security fix.
+  // ---------------------------------------------------------------------------
+
+  test("ignores forwarded host that is not on the allowlist", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "evil.attacker.com",
+      forwardedProto: "https",
+      requestOrigin,
+      pathname: "/login",
+      trustedHosts: ["xray.example.com"],
+    });
+    expect(url).toBe("https://xray.example.com/login");
+  });
+
+  test("ignores forwarded host when no allowlist is configured", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "evil.attacker.com",
+      forwardedProto: "https",
+      requestOrigin,
+      pathname: "/login",
+    });
+    expect(url).toBe("https://xray.example.com/login");
+  });
+
+  test("ignores forwarded host with a port suffix when allowlist names only the bare host", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "xray.example.com:8443",
+      forwardedProto: "https",
+      requestOrigin,
+      pathname: "/login",
+      trustedHosts: ["xray.example.com"],
+    });
+    expect(url).toBe("https://xray.example.com/login");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Trusted forwarded host is HONORED.
+  // ---------------------------------------------------------------------------
+
+  test("uses forwarded host when it matches the allowlist (case-insensitive)", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "Xray.Example.com",
+      forwardedProto: "https",
+      requestOrigin: "http://internal.local:7007",
+      pathname: "/",
+      trustedHosts: ["xray.example.com"],
+    });
+    expect(url).toBe("https://xray.example.com/");
+  });
+
+  test("forwarded host with valid proto uses that proto", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "xray.example.com",
+      forwardedProto: "http",
+      requestOrigin: "http://internal.local:7007",
+      pathname: "/login",
+      trustedHosts: ["xray.example.com"],
+    });
+    expect(url).toBe("http://xray.example.com/login");
+  });
+
+  test("forwarded host defaults proto to https when header missing", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "xray.example.com",
+      forwardedProto: null,
+      requestOrigin: "http://internal.local:7007",
+      pathname: "/login",
+      trustedHosts: ["xray.example.com"],
+    });
+    expect(url).toBe("https://xray.example.com/login");
+  });
+
+  test("forwarded host ignores junk proto values to prevent scheme injection", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: "xray.example.com",
+      forwardedProto: "javascript",
+      requestOrigin: "http://internal.local:7007",
+      pathname: "/login",
+      trustedHosts: ["xray.example.com"],
+    });
+    expect(url).toBe("https://xray.example.com/login");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fallback to the request's own origin.
+  // ---------------------------------------------------------------------------
+
+  test("uses request origin when no NEXTAUTH_URL and no forwarded host", () => {
+    const url = resolveRedirectUrl({
+      forwardedHost: null,
+      forwardedProto: null,
+      requestOrigin: "http://localhost:7007",
+      pathname: "/login",
+    });
+    expect(url).toBe("http://localhost:7007/login");
+  });
+});

--- a/src/lib/redirect-url.ts
+++ b/src/lib/redirect-url.ts
@@ -1,0 +1,47 @@
+// Build redirect URLs for auth flows without trusting attacker-controlled
+// forwarded headers. Order of precedence:
+//
+//   1. NEXTAUTH_URL — the configured canonical origin always wins. When the
+//      deployment knows its public URL, we never need to look at headers.
+//   2. x-forwarded-host on the allowlist (TRUSTED_FORWARDED_HOSTS).
+//   3. The request's own origin — same-host redirect, never cross-domain.
+//
+// This blocks CWE-601 (open redirect via Host / X-Forwarded-Host injection)
+// while still working behind a legitimate reverse proxy when configured.
+
+export interface ResolveRedirectInput {
+  forwardedHost: string | null;
+  forwardedProto: string | null;
+  requestOrigin: string;
+  pathname: string;
+  configuredUrl?: string;
+  trustedHosts?: string[];
+}
+
+export function parseTrustedHosts(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function safeProto(proto: string | null): "http" | "https" {
+  return proto === "http" || proto === "https" ? proto : "https";
+}
+
+export function resolveRedirectUrl(input: ResolveRedirectInput): string {
+  if (input.configuredUrl) {
+    return new URL(input.pathname, input.configuredUrl).toString();
+  }
+
+  const trusted = input.trustedHosts ?? [];
+  if (
+    input.forwardedHost &&
+    trusted.includes(input.forwardedHost.toLowerCase())
+  ) {
+    const proto = safeProto(input.forwardedProto);
+    return new URL(input.pathname, `${proto}://${input.forwardedHost}`).toString();
+  }
+
+  return new URL(input.pathname, input.requestOrigin).toString();
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,20 +1,24 @@
 import { auth } from "@/auth";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
+import {
+  parseTrustedHosts,
+  resolveRedirectUrl,
+} from "@/lib/redirect-url";
 
 // Skip auth in E2E test environment
 const SKIP_AUTH = process.env.E2E_SKIP_AUTH === "true";
 
-// Build redirect URL respecting reverse proxy headers
 function buildRedirectUrl(req: NextRequest, pathname: string): URL {
-  const forwardedHost = req.headers.get("x-forwarded-host");
-  const forwardedProto = req.headers.get("x-forwarded-proto") || "https";
-
-  if (forwardedHost) {
-    return new URL(pathname, `${forwardedProto}://${forwardedHost}`);
-  }
-
-  return new URL(pathname, req.nextUrl.origin);
+  const target = resolveRedirectUrl({
+    forwardedHost: req.headers.get("x-forwarded-host"),
+    forwardedProto: req.headers.get("x-forwarded-proto"),
+    requestOrigin: req.nextUrl.origin,
+    pathname,
+    configuredUrl: process.env.NEXTAUTH_URL || undefined,
+    trustedHosts: parseTrustedHosts(process.env.TRUSTED_FORWARDED_HOSTS),
+  });
+  return new URL(target);
 }
 
 // Next.js 16 proxy convention (replaces middleware.ts)


### PR DESCRIPTION
## Summary

- Stops trusting `x-forwarded-host` / `x-forwarded-proto` unconditionally when building auth-flow redirect URLs in `src/proxy.ts` — closes an open-redirect / host-header phishing path (CWE-601).
- Adds pure helper `src/lib/redirect-url.ts` with a fixed resolution order: `NEXTAUTH_URL` → `TRUSTED_FORWARDED_HOSTS` allowlist match → request's own origin.
- New env var `TRUSTED_FORWARDED_HOSTS` (comma-separated, case-insensitive, exact host match) documented in `.env.example` and `docs/05-config-and-data.md`.
- Untrusted scheme values (e.g. `javascript`) are ignored — only `http` / `https` are honored from `x-forwarded-proto`.

Production deploy is unaffected: `NEXTAUTH_URL=https://xray.hexly.ai` is already set on Railway, so the forwarded-host path is never consulted.

Tracks issue STU-644.

## Test plan

- [x] `bun run test` — 72 files / 1081 tests pass (new suite `src/__tests__/redirect-url.test.ts` covers untrusted host, no-allowlist fallback, port-suffix mismatch, case-insensitive trusted match, junk proto rejected, `NEXTAUTH_URL` precedence, request-origin fallback)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] `bun run test:coverage` — 96.69% statements / 91.33% branches (above thresholds)
- [x] Pre-push hook: lint + osv-scanner + e2e:api all green