### PR TITLE
security(auth): guard E2E_SKIP_AUTH bypass in requireAuth

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,6 +42,10 @@ export default defineConfig({
     timeout: webServerTimeout,
     env: {
       NODE_ENV: useProdServer ? "production" : "development",
+      // Opt-in marker required by `isE2EAuthBypass()` when the suite runs
+      // against a production-mode build — keeps the bypass scoped to the
+      // E2E runner and blocks accidental prod activation. See e2e-mode.ts.
+      E2E_TEST_RUNNER: "true",
       XRAY_DB: "database/xray.playwright.db",
       E2E_SKIP_AUTH: "true",
       MOCK_PROVIDER: "true",

--- a/src/__tests__/api-helpers.test.ts
+++ b/src/__tests__/api-helpers.test.ts
@@ -61,6 +61,41 @@ describe("requireAuth", () => {
     expect(result.db).toBeInstanceOf(ScopedDB);
     expect(mockAuth).not.toHaveBeenCalled();
   });
+
+  // STU-643: a stray E2E_SKIP_AUTH=true in production must NOT grant the
+  // e2e-test-user ScopedDB to unauthenticated callers.
+  test("ignores E2E_SKIP_AUTH in production without the test-runner marker", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("E2E_SKIP_AUTH", "true");
+    vi.stubEnv("E2E_TEST_RUNNER", "");
+    mockAuth.mockImplementation(() => Promise.resolve(null));
+    try {
+      const { requireAuth } = await import("@/lib/api-helpers");
+      const result = await requireAuth();
+      expect(result.db).toBeUndefined();
+      expect(result.error).toBeDefined();
+      expect(result.error!.status).toBe(401);
+      expect(mockAuth).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  // The L3 Playwright suite builds a production-mode server but explicitly
+  // opts in via E2E_TEST_RUNNER=true — that combination must still bypass.
+  test("honors E2E_SKIP_AUTH in production when E2E_TEST_RUNNER=true", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("E2E_SKIP_AUTH", "true");
+    vi.stubEnv("E2E_TEST_RUNNER", "true");
+    try {
+      const { requireAuth } = await import("@/lib/api-helpers");
+      const result = await requireAuth();
+      expect(result.db).toBeInstanceOf(ScopedDB);
+      expect(mockAuth).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
 });
 
 describe("requireAuthWithWatchlist", () => {

--- a/src/__tests__/e2e-mode.test.ts
+++ b/src/__tests__/e2e-mode.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect, afterEach, vi } from "vitest";
+import { isE2EAuthBypass } from "@/lib/e2e-mode";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("isE2EAuthBypass", () => {
+  test("returns false when E2E_SKIP_AUTH is unset", () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "");
+    vi.stubEnv("NODE_ENV", "development");
+    expect(isE2EAuthBypass()).toBe(false);
+  });
+
+  test("returns false when E2E_SKIP_AUTH is not exactly 'true'", () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "1");
+    vi.stubEnv("NODE_ENV", "development");
+    expect(isE2EAuthBypass()).toBe(false);
+  });
+
+  test("returns true when E2E_SKIP_AUTH=true in development", () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "true");
+    vi.stubEnv("NODE_ENV", "development");
+    expect(isE2EAuthBypass()).toBe(true);
+  });
+
+  test("returns true when E2E_SKIP_AUTH=true in test", () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "true");
+    vi.stubEnv("NODE_ENV", "test");
+    expect(isE2EAuthBypass()).toBe(true);
+  });
+
+  // The security fix: a stray E2E_SKIP_AUTH in prod must NOT bypass auth.
+  test("returns false in production even when E2E_SKIP_AUTH=true", () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "true");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("E2E_TEST_RUNNER", "");
+    expect(isE2EAuthBypass()).toBe(false);
+  });
+
+  test("returns false in production when only E2E_TEST_RUNNER is set", () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("E2E_TEST_RUNNER", "true");
+    expect(isE2EAuthBypass()).toBe(false);
+  });
+
+  // The L3 Playwright runner builds a production-mode server but explicitly
+  // opts in via E2E_TEST_RUNNER — that combination must still bypass.
+  test("returns true in production when both flags opt in", () => {
+    vi.stubEnv("E2E_SKIP_AUTH", "true");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("E2E_TEST_RUNNER", "true");
+    expect(isE2EAuthBypass()).toBe(true);
+  });
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import type { Adapter } from "@auth/core/adapters";
+import { isE2EAuthBypass } from "@/lib/e2e-mode";
 
 // Get allowed emails from environment variable
 const allowedEmails = (process.env.ALLOWED_EMAILS ?? "")
@@ -98,8 +99,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   },
   callbacks: {
     async signIn({ user }) {
-      // Skip email check in E2E test environment
-      if (process.env.E2E_SKIP_AUTH === "true") return true;
+      // Skip email check in E2E test environment (guarded — see e2e-mode.ts).
+      if (isE2EAuthBypass()) return true;
 
       const email = user.email?.toLowerCase();
       if (!email || !allowedEmails.includes(email)) {

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -2,6 +2,7 @@ import { auth } from "@/auth";
 import { NextResponse } from "next/server";
 import { ScopedDB } from "@/db/scoped";
 import { getDb, seedUser } from "@/db";
+import { isE2EAuthBypass } from "@/lib/e2e-mode";
 
 // E2E test bypass — when set, skip session auth and use a deterministic user.
 // Read at call-time (not module-load-time) so that tests can set the env var
@@ -16,13 +17,15 @@ const E2E_USER_ID = "e2e-test-user";
  * `account` table (provider + providerAccountId), so the session's user.id
  * is already the stable database ID. No ensureUserExists() needed for normal
  * auth flow. However, E2E_SKIP_AUTH bypasses OAuth entirely, so the user row
- * must be seeded explicitly to satisfy FK constraints.
+ * must be seeded explicitly to satisfy FK constraints. The bypass is gated by
+ * `isE2EAuthBypass()` so a stray `E2E_SKIP_AUTH=true` in production cannot
+ * grant unauthenticated callers a write-capable ScopedDB.
  */
 export async function requireAuth(): Promise<
   | { db: ScopedDB; error?: never }
   | { db?: never; error: NextResponse }
 > {
-  if (process.env.E2E_SKIP_AUTH === "true") {
+  if (isE2EAuthBypass()) {
     // Ensure the database is initialized before seeding — seedUser() uses the
     // raw sqlite driver which is only available after getDb() has been called.
     getDb();

--- a/src/lib/e2e-mode.ts
+++ b/src/lib/e2e-mode.ts
@@ -1,0 +1,25 @@
+/**
+ * Centralized guard for the E2E auth bypass.
+ *
+ * `E2E_SKIP_AUTH=true` makes `requireAuth()` return a deterministic
+ * `ScopedDB("e2e-test-user")` without checking the session, and tells
+ * the proxy + NextAuth `signIn` callback to skip the email allowlist.
+ * If that env var ever reached a production deploy, every API route
+ * protected by `requireAuth()` would silently fall through to a
+ * write-capable seed user — see STU-643.
+ *
+ * The bypass is only honored when EITHER:
+ *   1. `NODE_ENV !== "production"` — dev / test / vitest runs, or
+ *   2. `E2E_TEST_RUNNER === "true"` — the L3 Playwright runner builds
+ *      and starts vinext with `NODE_ENV=production` to avoid hydration
+ *      flake, so it must opt in explicitly.
+ *
+ * The production Dockerfile pins `NODE_ENV=production` and does NOT
+ * set `E2E_TEST_RUNNER`, so an accidentally-injected `E2E_SKIP_AUTH`
+ * at runtime cannot grant `e2e-test-user` access in prod.
+ */
+export function isE2EAuthBypass(): boolean {
+  if (process.env.E2E_SKIP_AUTH !== "true") return false;
+  if (process.env.NODE_ENV !== "production") return true;
+  return process.env.E2E_TEST_RUNNER === "true";
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,9 +5,7 @@ import {
   parseTrustedHosts,
   resolveRedirectUrl,
 } from "@/lib/redirect-url";
-
-// Skip auth in E2E test environment
-const SKIP_AUTH = process.env.E2E_SKIP_AUTH === "true";
+import { isE2EAuthBypass } from "@/lib/e2e-mode";
 
 function buildRedirectUrl(req: NextRequest, pathname: string): URL {
   const target = resolveRedirectUrl({
@@ -23,7 +21,7 @@ function buildRedirectUrl(req: NextRequest, pathname: string): URL {
 
 // Next.js 16 proxy convention (replaces middleware.ts)
 const authHandler = auth((req) => {
-  if (SKIP_AUTH) {
+  if (isE2EAuthBypass()) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary

Fixes STU-643 — `requireAuth()` in `src/lib/api-helpers.ts` honored `E2E_SKIP_AUTH=true` unconditionally. A stray flag in production would return a write-capable `ScopedDB("e2e-test-user")` to any unauthenticated API caller, granting silent read/write access on all session-protected routes.

## Changes

- **New** `src/lib/e2e-mode.ts` exports `isE2EAuthBypass()` — returns `true` only when `E2E_SKIP_AUTH=true` **and** (`NODE_ENV !== "production"` **or** explicit `E2E_TEST_RUNNER=true`).
- `src/lib/api-helpers.ts` `requireAuth()`, `src/auth.ts` `signIn` callback, and `src/proxy.ts` now route through the helper. No more bare `process.env.E2E_SKIP_AUTH === "true"` checks.
- `playwright.config.ts` injects `E2E_TEST_RUNNER=true` for the L3 Playwright runner (it builds with `NODE_ENV=production` to avoid hydration flake, so it must opt in explicitly).
- Production `Dockerfile` pins `NODE_ENV=production` and does **not** set `E2E_TEST_RUNNER`, so accidental injection of `E2E_SKIP_AUTH=true` at runtime cannot grant `e2e-test-user` access.

## Regression coverage

- `src/__tests__/e2e-mode.test.ts` — 7 cases covering the `NODE_ENV × E2E_SKIP_AUTH × E2E_TEST_RUNNER` matrix, including:
  - prod + `E2E_SKIP_AUTH=true` (no runner) → `false`
  - prod + `E2E_SKIP_AUTH=true` + `E2E_TEST_RUNNER=true` → `true`
- `src/__tests__/api-helpers.test.ts` — added two `requireAuth` cases:
  - prod + `E2E_SKIP_AUTH=true`, no session → returns 401, `auth()` is actually called (no bypass).
  - prod + `E2E_SKIP_AUTH=true` + `E2E_TEST_RUNNER=true` → returns ScopedDB (L3 path preserved).

## Review

Reviewer-03 approved commit `5239f0c` (2026-06-14 23:02 / 23:04).

## Local checks

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ 72 files / 1081 tests
- Pre-push hooks: build, L1, lint, osv-scanner, L2 API E2E — all green.

## Test plan

- [x] Vitest unit suite passes locally
- [x] L2 API E2E passes via pre-push hook
- [ ] CI: L1 + L2 + L3 (Playwright) green
- [ ] Verify a stray `E2E_SKIP_AUTH=true` in a prod-mode deploy yields 401 (covered by `api-helpers.test.ts`)