### PR TITLE
Add TweetClaw export import

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ x-ray/
 | `bun run db:studio` | 打开 Drizzle Studio |
 | `bun run db:generate` | 生成数据库迁移文件 |
 | `bun run db:migrate` | 执行数据库迁移 |
+| `bun run import:tweetclaw <file>` | 将 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) JSON、JSONL 或 CSV 导出转换为 `data/raw_tweets.json` |
 
 > 📖 **详细文档**: 更多关于架构、测试、部署和 API 的文档请参阅 [`docs/`](docs/) 目录
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepare": "husky",
     "release": "bun run scripts/release.ts",
     "watchlist": "bun run scripts/manage-watchlist.ts",
+    "import:tweetclaw": "bun run scripts/import-tweetclaw-export.ts",
     "xray-me": "bun run scripts/run-me-report.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/import-tweetclaw-export.ts
+++ b/scripts/import-tweetclaw-export.ts
@@ -1,0 +1,29 @@
+import { readFileSync, writeFileSync } from "fs";
+import { parseTweetClawExport } from "./lib/tweetclaw-import";
+import { RAW_TWEETS_PATH } from "./lib/utils";
+
+function usage(): string {
+  return [
+    "Usage:",
+    "  bun run scripts/import-tweetclaw-export.ts <tweetclaw-export> [output-json]",
+    "",
+    "Converts TweetClaw JSON, JSONL, or CSV exports into X-Ray raw_tweets.json.",
+  ].join("\n");
+}
+
+function main(): void {
+  const inputPath = process.argv[2];
+  const outputPath = process.argv[3] ?? RAW_TWEETS_PATH;
+
+  if (!inputPath) {
+    console.error(usage());
+    process.exit(1);
+  }
+
+  const content = readFileSync(inputPath, "utf8");
+  const rawTweets = parseTweetClawExport(content);
+  writeFileSync(outputPath, JSON.stringify(rawTweets, null, 2));
+  console.log(`Imported ${rawTweets.tweets.length} tweet(s) to ${outputPath}`);
+}
+
+main();

--- a/scripts/lib/tweetclaw-import.ts
+++ b/scripts/lib/tweetclaw-import.ts
@@ -1,0 +1,340 @@
+import type { RawTweetsFile, Tweet, TweetAuthor, TweetEntities, TweetMedia, TweetMetrics } from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+const WRAPPED_ARRAY_KEYS = ["tweets", "data", "results", "items", "records"];
+const TEXT_KEYS = ["text", "full_text", "fullText", "content", "tweet", "body"];
+const ID_KEYS = ["id", "tweet_id", "tweetId", "status_id", "statusId"];
+const CREATED_KEYS = ["created_at", "created", "createdAt", "posted_at", "published_at", "timestamp", "date"];
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function firstString(record: JsonRecord, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+    if (typeof value === "number" || typeof value === "bigint") {
+      return String(value);
+    }
+  }
+  return undefined;
+}
+
+function firstRecord(record: JsonRecord, keys: string[]): JsonRecord | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (isRecord(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value.replace(/,/g, ""));
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function firstNumber(record: JsonRecord, keys: string[]): number {
+  for (const key of keys) {
+    const value = record[key];
+    const parsed = toNumber(value);
+    if (parsed !== 0 || value === 0 || value === "0") {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    return normalized === "true" || normalized === "1" || normalized === "yes";
+  }
+  return value === 1;
+}
+
+function normalizeUsername(value: string | undefined): string {
+  return value?.replace(/^@/, "").trim() || "unknown";
+}
+
+function normalizeDate(value: string | undefined, fallback: string): string {
+  if (!value) {
+    return fallback;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+}
+
+function parseJsonRecords(content: string): JsonRecord[] | null {
+  try {
+    return recordsFromJson(JSON.parse(content));
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonlRecords(content: string): JsonRecord[] | null {
+  const lines = content.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const records: JsonRecord[] = [];
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+      if (!isRecord(parsed)) {
+        return null;
+      }
+      records.push(parsed);
+    } catch {
+      return null;
+    }
+  }
+  return records;
+}
+
+function parseCsvRows(content: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+
+    if (char === "\"") {
+      if (inQuotes && next === "\"") {
+        cell += "\"";
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === "," && !inQuotes) {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+
+    if ((char === "\n" || char === "\r") && !inQuotes) {
+      if (char === "\r" && next === "\n") {
+        index += 1;
+      }
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+
+    cell += char;
+  }
+
+  if (cell || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function parseCsvRecords(content: string): JsonRecord[] {
+  const rows = parseCsvRows(content).filter((row) => row.some((cell) => cell.trim()));
+  const header = rows.shift()?.map((cell) => cell.trim());
+  if (!header || header.length === 0) {
+    return [];
+  }
+
+  return rows.map((row) => {
+    const record: JsonRecord = {};
+    header.forEach((key, index) => {
+      if (key) {
+        record[key] = row[index]?.trim() ?? "";
+      }
+    });
+    return record;
+  });
+}
+
+function recordsFromJson(value: unknown): JsonRecord[] {
+  if (Array.isArray(value)) {
+    return value.filter(isRecord);
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  for (const key of WRAPPED_ARRAY_KEYS) {
+    const candidate = value[key];
+    if (Array.isArray(candidate)) {
+      return candidate.filter(isRecord);
+    }
+  }
+
+  return [value];
+}
+
+function normalizeMetrics(record: JsonRecord): TweetMetrics {
+  const nested = firstRecord(record, ["metrics", "public_metrics", "analytics"]) ?? record;
+  return {
+    retweet_count: firstNumber(nested, ["retweet_count", "retweets", "retweetCount", "repost_count", "reposts"]),
+    like_count: firstNumber(nested, ["like_count", "likes", "favorite_count", "favorites", "faves"]),
+    reply_count: firstNumber(nested, ["reply_count", "replies", "comments"]),
+    quote_count: firstNumber(nested, ["quote_count", "quotes"]),
+    view_count: firstNumber(nested, ["view_count", "views", "impressions"]),
+    bookmark_count: firstNumber(nested, ["bookmark_count", "bookmarks"]),
+  };
+}
+
+function normalizeAuthor(record: JsonRecord): TweetAuthor {
+  const author = firstRecord(record, ["author", "user", "account"]) ?? record;
+  const username = normalizeUsername(
+    firstString(author, ["username", "screen_name", "screenName", "handle"])
+      ?? firstString(record, ["username", "author_username", "screen_name", "user_screen_name"])
+  );
+
+  return {
+    id: firstString(author, ["id", "user_id", "userId", "author_id", "rest_id"]) ?? username,
+    username,
+    name: firstString(author, ["name", "display_name", "displayName", "author_name"]) ?? username,
+    profile_image_url: firstString(author, ["profile_image_url", "profileImageUrl", "avatar", "avatar_url"]),
+    followers_count: firstNumber(author, ["followers_count", "followers", "followersCount"]),
+    is_verified: toBoolean(author.verified ?? author.is_verified ?? author.isVerified),
+  };
+}
+
+function normalizeEntities(record: JsonRecord): TweetEntities | undefined {
+  const entities = firstRecord(record, ["entities"]) ?? record;
+  const hashtags = toStringArray(entities.hashtags);
+  const mentionedUsers = toStringArray(entities.mentioned_users ?? entities.mentions);
+  const urls = toStringArray(entities.urls);
+
+  if (hashtags.length === 0 && mentionedUsers.length === 0 && urls.length === 0) {
+    return undefined;
+  }
+
+  return {
+    hashtags,
+    mentioned_users: mentionedUsers,
+    urls,
+  };
+}
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.flatMap((item) => {
+    if (typeof item === "string" && item.trim()) {
+      return [item.trim()];
+    }
+    if (isRecord(item)) {
+      const text = firstString(item, ["text", "tag", "screen_name", "username", "url", "expanded_url"]);
+      return text ? [text] : [];
+    }
+    return [];
+  });
+}
+
+function normalizeMedia(record: JsonRecord): TweetMedia[] | undefined {
+  const rawMedia = record.media;
+  if (!Array.isArray(rawMedia)) {
+    return undefined;
+  }
+
+  const media = rawMedia.flatMap((item, index): TweetMedia[] => {
+    if (!isRecord(item)) {
+      return [];
+    }
+    const url = firstString(item, ["url", "media_url", "mediaUrl", "preview_image_url"]);
+    if (!url) {
+      return [];
+    }
+    const type = normalizeMediaType(firstString(item, ["type", "media_type", "mediaType"]));
+    return [{
+      id: firstString(item, ["id", "media_key", "mediaKey"]) ?? `${index}`,
+      type,
+      url,
+      thumbnail_url: firstString(item, ["thumbnail_url", "thumbnailUrl", "preview_image_url"]),
+    }];
+  });
+
+  return media.length > 0 ? media : undefined;
+}
+
+function normalizeMediaType(value: string | undefined): TweetMedia["type"] {
+  const normalized = value?.trim().toUpperCase();
+  if (normalized === "VIDEO" || normalized === "GIF") {
+    return normalized;
+  }
+  return "PHOTO";
+}
+
+function normalizeTweet(record: JsonRecord, fetchedAt: string, depth = 0): Tweet | null {
+  const source = isRecord(record.tweet) ? record.tweet : record;
+  const id = firstString(source, ID_KEYS);
+  const text = firstString(source, TEXT_KEYS);
+
+  if (!id || !text) {
+    return null;
+  }
+
+  const author = normalizeAuthor(source);
+  const createdAt = normalizeDate(firstString(source, CREATED_KEYS), fetchedAt);
+  const url = firstString(source, ["url", "tweet_url", "tweetUrl", "link"])
+    ?? `https://x.com/${author.username === "unknown" ? "i" : author.username}/status/${id}`;
+  const type = firstString(source, ["type", "tweet_type", "tweetType"])?.toLowerCase();
+  const quotedSource = depth === 0 && isRecord(source.quoted_tweet) ? normalizeTweet(source.quoted_tweet, fetchedAt, 1) : null;
+
+  return {
+    id,
+    text,
+    author,
+    created_at: createdAt,
+    url,
+    metrics: normalizeMetrics(source),
+    is_retweet: toBoolean(source.is_retweet ?? source.isRetweet) || type === "retweet",
+    is_quote: toBoolean(source.is_quote ?? source.isQuote ?? source.is_quote_status) || type === "quote" || quotedSource !== null,
+    is_reply: toBoolean(source.is_reply ?? source.isReply) || type === "reply",
+    lang: firstString(source, ["lang", "language"]),
+    media: normalizeMedia(source),
+    entities: normalizeEntities(source),
+    quoted_tweet: quotedSource ?? undefined,
+    reply_to_id: firstString(source, ["reply_to_id", "replyToId", "in_reply_to_id", "conversation_id"]),
+  };
+}
+
+export function parseTweetClawExport(content: string, fetchedAt = new Date().toISOString()): RawTweetsFile {
+  const trimmed = content.trim();
+  const records = parseJsonRecords(trimmed)
+    ?? parseJsonlRecords(trimmed)
+    ?? parseCsvRecords(trimmed);
+  const tweets = records
+    .map((record) => normalizeTweet(record, fetchedAt))
+    .filter((tweet): tweet is Tweet => tweet !== null);
+
+  return {
+    fetched_at: fetchedAt,
+    tweets,
+  };
+}

--- a/skills/xray-watchlist/SKILL.md
+++ b/skills/xray-watchlist/SKILL.md
@@ -33,6 +33,18 @@ JSON file at `data/raw_tweets.json` containing:
 }
 ```
 
+### import-tweetclaw-export.ts
+
+**Usage:**
+
+```bash
+bun run scripts/import-tweetclaw-export.ts ./tweetclaw-export.json
+```
+
+Converts a local [TweetClaw](https://github.com/Xquik-dev/tweetclaw) JSON, JSONL,
+or CSV export into `data/raw_tweets.json` so the normal X-Ray analysis and
+reporting workflow can run without a live fetch.
+
 Analyze output at `data/analyze_output.json` (STRICT JSON only):
 ```json
 {

--- a/tests/tweetclaw-import.test.ts
+++ b/tests/tweetclaw-import.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "vitest";
+import { parseTweetClawExport } from "../scripts/lib/tweetclaw-import";
+
+const FETCHED_AT = "2026-06-18T06:30:00.000Z";
+
+describe("tweetclaw-import", () => {
+  test("converts wrapped TweetClaw JSON records", () => {
+    const result = parseTweetClawExport(JSON.stringify({
+      tweets: [
+        {
+          id: "1900000000000000001",
+          text: "X-Ray can now import local TweetClaw exports.",
+          created: "2026-06-18T06:00:00.000Z",
+          username: "xray",
+          name: "X-Ray",
+          retweet_count: 2,
+          reply_count: 3,
+          like_count: 11,
+          quote_count: 1,
+          view_count: 900,
+          bookmark_count: 4,
+          is_quote_status: true,
+          lang: "en",
+        },
+      ],
+    }), FETCHED_AT);
+
+    expect(result.fetched_at).toBe(FETCHED_AT);
+    expect(result.tweets).toHaveLength(1);
+    expect(result.tweets[0]).toMatchObject({
+      id: "1900000000000000001",
+      text: "X-Ray can now import local TweetClaw exports.",
+      author: {
+        username: "xray",
+        name: "X-Ray",
+      },
+      created_at: "2026-06-18T06:00:00.000Z",
+      url: "https://x.com/xray/status/1900000000000000001",
+      is_quote: true,
+      lang: "en",
+      metrics: {
+        retweet_count: 2,
+        reply_count: 3,
+        like_count: 11,
+        quote_count: 1,
+        view_count: 900,
+        bookmark_count: 4,
+      },
+    });
+  });
+
+  test("converts TweetClaw JSONL with nested author and metrics", () => {
+    const lines = [
+      JSON.stringify({
+        tweetId: "1900000000000000002",
+        fullText: "Nested JSONL export works too.",
+        createdAt: "2026-06-18T06:05:00.000Z",
+        author: {
+          id: "user-1",
+          username: "@builder",
+          displayName: "Builder",
+          followers: 1200,
+          verified: "true",
+        },
+        metrics: {
+          retweets: "5",
+          likes: "25",
+          replies: "2",
+          quotes: "1",
+          views: "1,500",
+          bookmarks: "7",
+        },
+        entities: {
+          hashtags: ["agents"],
+          urls: [{ expanded_url: "https://example.com/post" }],
+        },
+      }),
+      JSON.stringify({ id: "skip-me" }),
+    ].join("\n");
+
+    const result = parseTweetClawExport(lines, FETCHED_AT);
+
+    expect(result.tweets).toHaveLength(1);
+    expect(result.tweets[0]).toMatchObject({
+      id: "1900000000000000002",
+      author: {
+        id: "user-1",
+        username: "builder",
+        name: "Builder",
+        followers_count: 1200,
+        is_verified: true,
+      },
+      metrics: {
+        retweet_count: 5,
+        like_count: 25,
+        reply_count: 2,
+        quote_count: 1,
+        view_count: 1500,
+        bookmark_count: 7,
+      },
+      entities: {
+        hashtags: ["agents"],
+        urls: ["https://example.com/post"],
+      },
+    });
+  });
+
+  test("converts TweetClaw CSV rows", () => {
+    const csv = [
+      "tweet_id,text,author_username,created_at,like_count,retweet_count,reply_count,url",
+      "1900000000000000003,\"CSV, with punctuation\",analyst,2026-06-18T06:10:00.000Z,8,2,1,https://x.com/analyst/status/1900000000000000003",
+    ].join("\n");
+
+    const result = parseTweetClawExport(csv, FETCHED_AT);
+
+    expect(result.tweets).toHaveLength(1);
+    expect(result.tweets[0]).toMatchObject({
+      id: "1900000000000000003",
+      text: "CSV, with punctuation",
+      author: {
+        username: "analyst",
+      },
+      metrics: {
+        like_count: 8,
+        retweet_count: 2,
+        reply_count: 1,
+      },
+      url: "https://x.com/analyst/status/1900000000000000003",
+    });
+  });
+
+  test("converts quoted tweets and media variants", () => {
+    const result = parseTweetClawExport(JSON.stringify([{
+      statusId: "1900000000000000004",
+      body: "Quote with media.",
+      date: "not-a-date",
+      handle: "",
+      type: "quote",
+      media: [
+        { id: "m1", type: "video", url: "https://example.com/video.mp4", thumbnail_url: "https://example.com/thumb.jpg" },
+        { id: "m2", type: "gif", url: "https://example.com/clip.gif" },
+        { id: "m3", type: "image", media_url: "https://example.com/photo.jpg" },
+        { id: "m4", type: "video" },
+        "bad-media",
+      ],
+      quoted_tweet: {
+        id: "1900000000000000005",
+        text: "Quoted root.",
+        username: "quoted",
+      },
+    }]), FETCHED_AT);
+
+    expect(result.tweets).toHaveLength(1);
+    expect(result.tweets[0]).toMatchObject({
+      id: "1900000000000000004",
+      author: {
+        username: "unknown",
+      },
+      created_at: "not-a-date",
+      is_quote: true,
+      media: [
+        { id: "m1", type: "VIDEO", url: "https://example.com/video.mp4" },
+        { id: "m2", type: "GIF", url: "https://example.com/clip.gif" },
+        { id: "m3", type: "PHOTO", url: "https://example.com/photo.jpg" },
+      ],
+      quoted_tweet: {
+        id: "1900000000000000005",
+        author: {
+          username: "quoted",
+        },
+      },
+    });
+  });
+
+  test("handles fallback inputs without importing invalid tweets", () => {
+    expect(parseTweetClawExport("", FETCHED_AT).tweets).toEqual([]);
+    expect(parseTweetClawExport("not json\nalso not json", FETCHED_AT).tweets).toEqual([]);
+    expect(parseTweetClawExport("42", FETCHED_AT).tweets).toEqual([]);
+    expect(parseTweetClawExport(JSON.stringify({ data: [42, null, { id: "missing-text" }] }), FETCHED_AT).tweets).toEqual([]);
+  });
+
+  test("parses CSV escaped quotes and CRLF rows", () => {
+    const csv = [
+      "id,text,screen_name,is_retweet",
+      "1900000000000000006,\"He said \"\"ship it\"\"\",dev,true",
+    ].join("\r\n");
+
+    const result = parseTweetClawExport(csv, FETCHED_AT);
+
+    expect(result.tweets).toHaveLength(1);
+    expect(result.tweets[0]).toMatchObject({
+      id: "1900000000000000006",
+      text: "He said \"ship it\"",
+      author: {
+        username: "dev",
+      },
+      is_retweet: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a TweetClaw export parser for JSON, JSONL, and CSV inputs
- add `bun run import:tweetclaw <file> [output]` to write X-Ray's existing `raw_tweets.json` shape
- document the optional offline import path in the README and `xray-watchlist` skill

## Validation
- `bun run test tests/tweetclaw-import.test.ts`
- `bun run test tests/tweet-utils.test.ts`
- `bun run typecheck`
- `bun run lint scripts/lib/tweetclaw-import.ts scripts/import-tweetclaw-export.ts`
- `bun run test:coverage` (1,096 tests, branch coverage 91.57%)
- `bun run build`
- `gitleaks protect --staged --no-banner`
- `osv-scanner scan --lockfile=bun.lock --config=osv-scanner.toml`
- CLI smoke conversion to `/tmp/tweetclaw-xray-smoke-output.json`