### PR TITLE
chore(ci): pin base-ci reusable workflow to v2026.5 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
     with:
       test-command: "bun run test:coverage"
       typecheck-command: "echo 'no typecheck configured'"


### PR DESCRIPTION
## Summary

Pin the `nocoo/base-ci` reusable workflow reference in `.github/workflows/ci.yml` from the floating tag `@v2026.4` to the immutable commit SHA for v2026.5 (`aec4adc1a817c56790d1698329ef9398a15a754a`).

```diff
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
```

## Why

Floating `@v2026.x` tags can be silently re-pointed if the upstream tag is moved or force-pushed, violating supply-chain best practices. Pinning third-party reusable workflows to a 40-char commit SHA makes the reference byte-immutable — even an upstream compromise cannot inject different code into this workflow. The trailing `# v2026.5` comment preserves the human-readable version.

## Scope

- Single file, single line: `.github/workflows/ci.yml:12`
- `rg "nocoo/base-ci|@v2026\."` over `.github/workflows` confirms no other floating references remain.

## Verification

- [x] `actionlint .github/workflows/*.yml` — clean
- [x] Single atomic commit (`chore(ci): pin base-ci reusable workflow to v2026.5 SHA`)
- [x] SHA `aec4adc1a817c56790d1698329ef9398a15a754a` matches `git ls-remote ... refs/tags/v2026.5^{}` (peeled commit)
- [ ] CI green on this PR

Refs: STU-932
