### PR TITLE
chore(deps): bump @ai-sdk/anthropic 3.0.85 → 3.0.86

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "x-ray",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.85",
+        "@ai-sdk/anthropic": "^3.0.86",
         "@ai-sdk/openai": "^3.0.74",
         "@radix-ui/react-collapsible": "^1.1.14",
         "ai": "^6.0.209",
@@ -62,7 +62,7 @@
     "react-server-dom-webpack": ">=19.2.6",
   },
   "packages": {
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.85", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.86", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-IVUaTOz46dNniRaALEvphV5WOqPfKTJRZlJhJabz3kaXk1QiwdnzWQhKMKLiprD+872E9YHqmmyFNFFH1MfnBQ=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.134", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.30", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-PfUkQp01EihEyNM6e+nexXmVANiY5KcHMui/MmaHsC4KVVQYh/MwPeOsD3bTPu63e581BKO+AwaPPNmD4x943A=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.85",
+    "@ai-sdk/anthropic": "^3.0.86",
     "@ai-sdk/openai": "^3.0.74",
     "@radix-ui/react-collapsible": "^1.1.14",
     "ai": "^6.0.209",


### PR DESCRIPTION
## Summary

Patch bump `@ai-sdk/anthropic` 3.0.85 → 3.0.86.

- `package.json` + `bun.lock` only
- Clean reinstall (`rm -rf node_modules .next && bun install`) to avoid `.bun` cache残留
- `typecheck` / `lint` / `test` (1090 passed) / `build` all green

Closes nocoo/xray#135
