### PR TITLE
fix(e2e): give each dev server its own vite cacheDir

### DIFF
--- a/scripts/run-e2e-api.ts
+++ b/scripts/run-e2e-api.ts
@@ -90,6 +90,7 @@ async function startServer(opts: {
   port: number;
   db: string;
   skipAuth: boolean;
+  cacheDir: string;
 }): Promise<ServerHandle> {
   console.log(`🌐 Starting ${opts.name} on :${opts.port}...`);
 
@@ -108,6 +109,10 @@ async function startServer(opts: {
     // (auth-bypass + no-auth), so opt out — port collisions are already
     // prevented by ensurePortFree() above.
     VINEXT_NO_DEV_LOCK: "1",
+    // Give each dev server its own vite cacheDir. Without this, both processes
+    // race on node_modules/.vite/deps_ssr and the second `rename(temp → final)`
+    // hits ENOTEMPTY because the first one already committed the directory.
+    VITE_CACHE_DIR: opts.cacheDir,
   };
   if (opts.skipAuth) env.E2E_SKIP_AUTH = "true";
 
@@ -169,12 +174,14 @@ async function main(): Promise<void> {
     port: AUTH_PORT,
     db: AUTH_DB,
     skipAuth: true,
+    cacheDir: "node_modules/.vite-auth",
   });
   const noAuthServer = await startServer({
     name: "no-auth server",
     port: NO_AUTH_PORT,
     db: NO_AUTH_DB,
     skipAuth: false,
+    cacheDir: "node_modules/.vite-noauth",
   });
 
   const [authReady, noAuthReady] = await Promise.all([

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [vinext()],
+  // Allow per-process cacheDir so concurrent `vinext dev` instances (E2E
+  // runner spawns auth-bypass + no-auth in parallel) don't race on the same
+  // node_modules/.vite/deps_ssr rename. Set VITE_CACHE_DIR per spawn.
+  cacheDir: process.env.VITE_CACHE_DIR,
   server: {
     allowedHosts: true,
   },


### PR DESCRIPTION
## Summary

Fix the L2 API E2E auth-bypass server failing to start in CI with `ENOTEMPTY: directory not empty, rename ... deps_ssr_temp_xxx -> deps_ssr` (run [28276010911](https://github.com/nocoo/xray/actions/runs/28276010911)).

`scripts/run-e2e-api.ts` spawns two `vinext dev` instances (`auth-bypass` on :17007, `no-auth` on :17029) in the same project root. Both initialize Vite dependency optimization concurrently, race on `node_modules/.vite/deps_ssr`, and the loser hits `ENOTEMPTY` when committing the optimized deps.

The minimum-surface fix: read `cacheDir` from `process.env.VITE_CACHE_DIR` in `vite.config.ts`, and inject `node_modules/.vite-auth` vs `node_modules/.vite-noauth` per spawn. Default behaviour (`vinext dev`, `vinext build`) is unchanged when the env var is unset.

## Verification

- `bun run test:e2e:api` × 4 (3 by author + 1 by reviewer) — all green, `205 pass / 4 skip / 0 fail`. Plus 1 more from pre-push hook on this push.
- `bun run lint` — clean (eslint `--max-warnings=0`).
- `bun run test:coverage` — `1090/1090` passing, 96.97% statement coverage.
- `gitleaks protect --staged --no-banner` — no leaks.
- Reviewer-02 APPROVE on STU-1355 (Group-02 pair review).

## Test plan

- [x] L2 API E2E (`bun run test:e2e:api`) passes locally with both warm and cold vite cache
- [x] Pre-push hook (build + L1 + lint + osv-scanner + L2 e2e) passes
- [ ] CI: L1 / L2 API E2E / L3 (this fails on `main`, so the PR's `pull_request` event won't trigger the failing path — fix only validates once merged + `push` event runs on `main`)

Refs STU-1355.
