### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
## Summary

Add root `.npmrc` for supply chain security baseline.

- Pin registry to official `registry.npmjs.org/` (防钓鱼源)
- Enforce lockfile integrity: `save-exact=true`, `package-lock=true`
- `engine-strict=true` for Node/npm 版本一致性
- `audit=true`, `audit-level=high`; `fund=false` 降噪

不加 `ignore-scripts=true`（会破坏 prisma / esbuild / puppeteer 等的 postinstall），投毒防护走后续 `trustedDependencies` 白名单方案。

## Scope

- **1 file, +21 lines, config-only**：仅新增 `.npmrc`
- 未动 `package.json` / `bun.lock` / `bunfig.toml` / CI / hooks
- 未运行 `bun install`

## Verification

- `cat .npmrc` 与 issue 模板逐字一致
- `git diff --stat HEAD~1 HEAD` → `.npmrc | 21 +++++++++++++++++++++`
- `git diff --check HEAD~1 HEAD` 无输出
- Reviewer-03 已通过 review

Refs STU-1521.
